### PR TITLE
chore: split up ruff into separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,16 +6,15 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the "master" branch
   push:
-    branches: [ "master", "compose" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "compose" ]
+    branches: [ "master" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -42,6 +41,14 @@ jobs:
       - name: Run a multi-line script
         run: |
           docker compose up -d
+  check:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
       # run python linter and formatter on runner
       - name: install ruff using pip
         run: |


### PR DESCRIPTION
enables checking in pull request directly what has failed, enables running in parallel

implementation (build & check separated): easier to see that the build has not failed
<img width="573" alt="Screenshot 2025-02-07 at 17 29 21" src="https://github.com/user-attachments/assets/aa9c0080-a7e8-4eb9-ad42-010b5725cca7" />

currently: no discernible way to know that only lints/formatting failed
<img width="566" alt="Screenshot 2025-02-07 at 17 30 51" src="https://github.com/user-attachments/assets/c6f8eb9b-31dd-4d05-9e9c-bbf7e61cf156" />

