### PR TITLE
Feat/block dashboard

### DIFF
--- a/backend/dashboard/static/dashboard/css/profile.css
+++ b/backend/dashboard/static/dashboard/css/profile.css
@@ -59,3 +59,22 @@
 	margin-bottom: 5px;
 	font-size: 16px;
 }
+
+#pv-profile-settings-content {
+	margin-bottom: 10px;
+}
+
+#pv-show-blocked-users {
+	margin-bottom: 5px;
+}
+
+.pv-blocked-user-item {
+	font-size: 18px;
+}
+
+.pv-unblock-button {
+	margin-left: 5px;
+	height: 30px;
+	font-size: 16px;
+	padding: 2px;
+}

--- a/backend/dashboard/static/dashboard/css/profile.css
+++ b/backend/dashboard/static/dashboard/css/profile.css
@@ -11,6 +11,14 @@
 	margin-bottom: 20px;
 }
 
+#pv-block-button {
+	margin-left: auto;
+}
+
+#pv-settings-button {
+	margin-left: auto;
+}
+
 #pv-profile-name {
 	font-size: 60px;
 	font-weight: bold;

--- a/backend/dashboard/static/dashboard/js/profile.js
+++ b/backend/dashboard/static/dashboard/js/profile.js
@@ -22,6 +22,9 @@ function fetchData(username) {
 		.then(response => response.json())
 		.then(data => {
 			if (data.success) {
+				if (data.blocked === true) {
+					displayBlockedProfile(data);
+				}
 				console.log('Profile:', data.profile);
 				displayProfile(data.profile);
 			} else {
@@ -50,4 +53,17 @@ function displayProfile(profile) {
 		<li>${gettext("Questions Asked:")} ${profile.quiz_questions_asked}</li>
 		<li>${gettext("Correct Answers:")} ${profile.quiz_correct_answers}</li>
 	`;
+}
+
+function displayBlockedProfile(data) {
+	const profilePicture = document.getElementById('pv-profile-picture');
+	profilePicture.src = data.image_url;
+	profilePicture.alt = `${data.username}${gettext("'s profile picture")}`;
+	const profileName = document.getElementById('pv-profile-name');
+	profileName.textContent = `${data.username}${gettext("'s Profile")}`;
+
+	const profileContent = document.getElementById('pv-profile-content');
+	const paragraph = document.createElement('p');
+	paragraph.id = 'profile-is-blocked';
+	paragraph.innerHTML = `${gettext("This user has blocked you. You cannot view their profile.")}`;
 }

--- a/backend/dashboard/static/dashboard/js/profile.js
+++ b/backend/dashboard/static/dashboard/js/profile.js
@@ -222,20 +222,28 @@ function addBlockedUsersList(profile) {
 			const blockedUsersList = document.getElementById('pv-blocked-users-list');
 			blockedUsersList.style.visibility = 'visible';
 			blockedUsersList.innerHTML = '';
-			data.blocked_users.forEach(username => {
-				const userItem = document.createElement('div');
-				userItem.className = 'pv-blocked-user-item';
-				userItem.innerHTML = `
-					<span>${username}</span>
-					<button class="btn btn-danger pv-unblock-button" data-username="${username}">${gettext("Unblock")}</button>
-				`;
-				blockedUsersList.appendChild(userItem);
-			});
+			if (data.blocked_users.length === 0) {
+				const noBlockedUsers = document.createElement('p');
+				noBlockedUsers.textContent = gettext('No blocked users');
+				blockedUsersList.appendChild(noBlockedUsers);
+			}
+			else {
+				data.blocked_users.forEach(username => {
+					const userItem = document.createElement('div');
+					userItem.className = 'pv-blocked-user-item';
+					userItem.innerHTML = `
+						<span>${username}</span>
+						<button class="btn btn-danger pv-unblock-button" data-username="${username}">${gettext("Unblock")}</button>
+					`;
+					blockedUsersList.appendChild(userItem);
+				});
+			}
 			const unblockButtons = document.querySelectorAll('.pv-unblock-button');
 			unblockButtons.forEach(button => {
 				button.addEventListener('click', function () {
 					const username = button.getAttribute('data-username');
-					if (button.textContent = gettext('Unblock')) {
+					if (button.textContent === gettext('Unblock')) {
+						console.log("HEllo");
 						fetch(`/users/api/unblock/${username}/`, {
 							method: 'POST',
 							headers: {
@@ -248,7 +256,7 @@ function addBlockedUsersList(profile) {
 							alert(data.message);
 							if (data.success) {
 								console.log('User unblocked');
-								button.textContent = gettext('Blocked');
+								button.textContent = gettext('Block');
 							} else {
 								console.error('Failed to unblock user');
 							}

--- a/backend/dashboard/static/dashboard/js/profile.js
+++ b/backend/dashboard/static/dashboard/js/profile.js
@@ -27,19 +27,21 @@ function fetchData(username) {
 			return response.json();
 		})
 		.then(data => {
+			console.log('Data:', data);
 			if (data.success) {
 				if (data.blocked === true) {
 					displayBlockedProfile(data);
+				} else {
+					console.log('Profile:', data.profile);
+					displayProfile(data.profile);
 				}
-				console.log('Profile:', data.profile);
-				displayProfile(data.profile);
 			} else {
 				console.error('Failed to fetch profile');
 			}
 		})
 		.catch(error => {
 			console.error('Error:', error);
-			dashboardAppContent.innerHTML = `<h3>Error loading profile for ${username}</h3>`;
+			dashboardAppContent.innerHTML = `<h3>${gettext("Error loading profile for")} ${username}</h3>`;
 		});
 }
 
@@ -49,6 +51,42 @@ function displayProfile(profile) {
 	profilePicture.alt = `${profile.username}${gettext("'s profile picture")}`;
 	const profileName = document.getElementById('pv-profile-name');
 	profileName.textContent = `${profile.username}${gettext("'s Profile")}`;
+
+	if (profile.is_requests_profile === false) {
+		const profileHeader = document.getElementById('pv-profile-header');
+		const blockButton = document.createElement('button');
+		blockButton.id = 'pv-block-button';
+		blockButton.className = 'btn btn-danger';
+		profileHeader.appendChild(blockButton);
+
+		if (profile.is_user_blocked_by_requester === true) {
+			blockButton.textContent = gettext('Unblock');
+		} else {
+			blockButton.textContent = gettext('Block');
+		}
+		blockButton.addEventListener('click', function () {
+			if (blockButton.textContent === gettext('Block')) {
+				blockUser(profile.username);
+			} else {
+				unblockUser(profile.username);
+			}
+		});
+	} else {
+		const profileHeader = document.getElementById('pv-profile-header');
+		const settingsButton = document.createElement('button');
+
+		settingsButton.id = 'pv-settings-button';
+		settingsButton.className = 'btn btn-primary';
+		settingsButton.innerHTML = `
+			<i class="bi bi-gear-fill"></i>
+			<span class="sr-only">${gettext("Settings")}</span>
+		`;
+		profileHeader.appendChild(settingsButton);
+
+		settingsButton.addEventListener('click', function () {
+			router.navigateTo('/account/');
+		});
+	}
 
 	const quizStatsList = document.getElementById('pv-quiz-stats-list');
 	quizStatsList.innerHTML = `
@@ -62,6 +100,7 @@ function displayProfile(profile) {
 }
 
 function displayBlockedProfile(data) {
+	console.log('Blocked:', data);
 	const profilePicture = document.getElementById('pv-profile-picture');
 	profilePicture.src = data.image_url;
 	profilePicture.alt = `${data.username}${gettext("'s profile picture")}`;
@@ -69,7 +108,81 @@ function displayBlockedProfile(data) {
 	profileName.textContent = `${data.username}${gettext("'s Profile")}`;
 
 	const profileContent = document.getElementById('pv-profile-content');
+	profileContent.innerHTML = '';
 	const paragraph = document.createElement('p');
 	paragraph.id = 'profile-is-blocked';
 	paragraph.innerHTML = `${gettext("This user has blocked you. You cannot view their profile.")}`;
+	profileContent.appendChild(paragraph);
+
+	const profileHeader = document.getElementById('pv-profile-header');
+	const blockButton = document.createElement('button');
+	blockButton.id = 'pv-block-button';
+	blockButton.className = 'btn btn-danger';
+	profileHeader.appendChild(blockButton);
+
+	if (data.is_user_blocked_by_requester === true) {
+		blockButton.textContent = gettext('Unblock');
+	} else {
+		blockButton.textContent = gettext('Block');
+	}
+	blockButton.addEventListener('click', function () {
+		if (blockButton.textContent === gettext('Block')) {
+			blockUser(data.username);
+		} else {
+			unblockUser(data.username);
+		}
+	});
+
+}
+
+function blockUser(username) {
+	const csfrToken = document.querySelector('meta[name="csrf-token"]').content;
+
+	fetch(`/users/api/block/${username}/`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'X-CSRFToken': csfrToken,
+		}
+	})
+	.then(response => response.json())
+	.then(data => {
+		alert(data.message);
+		if (data.success) {
+			console.log('User blocked');
+			const blockButton = document.getElementById('pv-block-button');
+			blockButton.textContent = gettext('Unblock');
+		} else {
+			console.error('Failed to block user');
+		}
+	})
+	.catch(error => {
+		console.error('Error:', error);
+	});
+}
+
+function unblockUser(username) {
+	const csfrToken = document.querySelector('meta[name="csrf-token"]').content;
+
+	fetch(`/users/api/unblock/${username}/`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'X-CSRFToken': csfrToken,
+		}
+	})
+	.then(response => response.json())
+	.then(data => {
+		alert(data.message);
+		if (data.success) {
+			console.log('User unblocked');
+			const blockButton = document.getElementById('pv-block-button');
+			blockButton.textContent = gettext('Block');
+		} else {
+			console.error('Failed to unblock user');
+		}
+	})
+	.catch(error => {
+		console.error('Error:', error);
+	});
 }

--- a/backend/dashboard/static/dashboard/js/profile.js
+++ b/backend/dashboard/static/dashboard/js/profile.js
@@ -19,7 +19,13 @@ export function loadProfile(username) {
 
 function fetchData(username) {
 	fetch(`/dashboard/api/get_profile/${username}/`)
-		.then(response => response.json())
+		.then(response => {
+			if (response.redirected) {
+				router.navigateTo('/login/');
+				return;
+			}
+			return response.json();
+		})
 		.then(data => {
 			if (data.success) {
 				if (data.blocked === true) {

--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -1,8 +1,7 @@
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from user_management.models import CustomUser
-from user_management.blocked_users import Block_Manager, BlockedUsers
-from django.utils.translation import gettext as _
+from user_management.blocked_users import Block_Manager
 from transcendence.decorators import login_required_redirect
 
 def profile_list(request):

--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -1,6 +1,8 @@
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from user_management.models import CustomUser
+from user_management.blocked_users import Block_Manager, BlockedUsers
+from django.utils.translation import gettext as _
 
 
 def profile_list(request):
@@ -29,6 +31,15 @@ def get_profile(request, username):
 	print(f"Username: {username}", flush=True)
 	user = get_object_or_404(CustomUser, username=username)
 	print(f"User: {user}", flush=True)
+
+	if Block_Manager.is_blocked_by(blockee=request.user, blocker=user):
+		return JsonResponse({
+			'success': True,
+			'username': user.username,
+			'image_url': user.image.url,
+			'blocked': True,
+		})
+
 	profile_data = {
 		'username': user.username,
 		'image_url': user.image.url,
@@ -42,4 +53,5 @@ def get_profile(request, username):
 	return JsonResponse({
 		'success': True,
 		'profile': profile_data,
+		'blocked': False,
 	})

--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import get_object_or_404
 from user_management.models import CustomUser
 from user_management.blocked_users import Block_Manager, BlockedUsers
 from django.utils.translation import gettext as _
-
+from transcendence.decorators import login_required_redirect
 
 def profile_list(request):
 	"""
@@ -23,6 +23,7 @@ def profile_list(request):
 		'profiles': profile_data,
 	})
 
+@login_required_redirect
 def get_profile(request, username):
 	"""
 	Api call that returns a specific profile.

--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -33,12 +33,21 @@ def get_profile(request, username):
 	user = get_object_or_404(CustomUser, username=username)
 	print(f"User: {user}", flush=True)
 
+	is_requests_profile = False
+	is_user_blocked_by_requester = False
+	if (request.user == user):
+		is_requests_profile = True
+	else:
+		if Block_Manager.is_blocked_by(blockee=user, blocker=request.user):
+			is_user_blocked_by_requester = True
+
 	if Block_Manager.is_blocked_by(blockee=request.user, blocker=user):
 		return JsonResponse({
 			'success': True,
 			'username': user.username,
 			'image_url': user.image.url,
 			'blocked': True,
+			'is_user_blocked_by_requester': is_user_blocked_by_requester,
 		})
 
 	profile_data = {
@@ -50,6 +59,8 @@ def get_profile(request, username):
 		'quiz_high_score': user.quiz_high_score,
 		'quiz_questions_asked': user.quiz_questions_asked,
 		'quiz_correct_answers': user.quiz_correct_answers,
+		'is_requests_profile': is_requests_profile,
+		'is_user_blocked_by_requester': is_user_blocked_by_requester,
 	}
 	return JsonResponse({
 		'success': True,

--- a/backend/locale/de/LC_MESSAGES/django.po
+++ b/backend/locale/de/LC_MESSAGES/django.po
@@ -58,7 +58,7 @@ msgstr "Deutsch"
 #, fuzzy
 #| msgid "Password changed successfully."
 msgid "User blocked successfully."
-msgstr "Passwort wurde erfolgreich geändert."
+msgstr "Benutzer wurde erfolgreich blockiert."
 
 #: user_management/views.py:42 user_management/views.py:56
 #: user_management/views.py:99 user_management/views.py:121
@@ -71,7 +71,7 @@ msgstr "Ungültige Anforderungsmethode."
 #, fuzzy
 #| msgid "Password changed successfully."
 msgid "User unblocked successfully."
-msgstr "Passwort wurde erfolgreich geändert."
+msgstr "Benutzer ist nun nicht mehr blockiert."
 
 #: user_management/views.py:88
 msgid "Passwords do not match."

--- a/backend/locale/de/LC_MESSAGES/django.po
+++ b/backend/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-08 17:45+0000\n"
+"POT-Creation-Date: 2025-02-12 12:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,68 +54,91 @@ msgstr "Schwedisch"
 msgid "German"
 msgstr "Deutsch"
 
-#: user_management/views.py:41
-msgid "Passwords do not match."
-msgstr "Passwörter stimmen nicht überein."
+#: user_management/views.py:40
+#, fuzzy
+#| msgid "Password changed successfully."
+msgid "User blocked successfully."
+msgstr "Passwort wurde erfolgreich geändert."
 
-#: user_management/views.py:50
-msgid "Account created successfully."
-msgstr "Benutzerkonto wurde erfolgreich erstellt."
-
-#: user_management/views.py:52 user_management/views.py:74
-#: user_management/views.py:89 user_management/views.py:110
-#: user_management/views.py:143 user_management/views.py:212
+#: user_management/views.py:42 user_management/views.py:56
+#: user_management/views.py:99 user_management/views.py:121
+#: user_management/views.py:136 user_management/views.py:157
+#: user_management/views.py:190 user_management/views.py:263
 msgid "Invalid request method."
 msgstr "Ungültige Anforderungsmethode."
 
-#: user_management/views.py:69
+#: user_management/views.py:54
+#, fuzzy
+#| msgid "Password changed successfully."
+msgid "User unblocked successfully."
+msgstr "Passwort wurde erfolgreich geändert."
+
+#: user_management/views.py:88
+msgid "Passwords do not match."
+msgstr "Passwörter stimmen nicht überein."
+
+#: user_management/views.py:97
+msgid "Account created successfully."
+msgstr "Benutzerkonto wurde erfolgreich erstellt."
+
+#: user_management/views.py:116
 msgid "Login successful."
 msgstr "Anmeldung war erfolgreich."
 
-#: user_management/views.py:72
+#: user_management/views.py:119
 msgid "Invalid username or password!"
 msgstr "Ungülter Benutzername or Passwort!"
 
-#: user_management/views.py:86
+#: user_management/views.py:133
 msgid "Logout successful."
 msgstr "Abmeldung war erfolgreich."
 
-#: user_management/views.py:132
+#: user_management/views.py:179
 msgid "Invalid password."
 msgstr "Ungültiges Passwort."
 
-#: user_management/views.py:142
+#: user_management/views.py:189
 msgid "Profile updated successfully."
 msgstr "Profil erfolgreich aktualisiert."
 
-#: user_management/views.py:151
+#: user_management/views.py:198
 msgid "Invalid email address."
 msgstr "Ungültige E-Mail Addresse"
 
-#: user_management/views.py:155 user_management/views.py:160
+#: user_management/views.py:202 user_management/views.py:207
 msgid "An Account with this email already exists."
 msgstr "Ein Benutzerkonto mit dieser E-Mail existiert bereits."
 
-#: user_management/views.py:167
-msgid "Invalid username. Username must contain only letters, numbers, and underscores, and cannot be empty or contain only whitespace."
-msgstr "Ungültiger Benutzername. Der Benutzername darf nur Buchstaben, Zahlen und Unterstriche enthalten und darf nicht leer sein oder nur Leerzeichen enthalten."
+#: user_management/views.py:215
+msgid ""
+"Invalid username. Username must contain only letters, numbers, and "
+"underscores, and cannot be empty or contain only whitespace."
+msgstr ""
+"Ungültiger Benutzername. Der Benutzername darf nur Buchstaben, Zahlen und "
+"Unterstriche enthalten und darf nicht leer sein oder nur Leerzeichen "
+"enthalten."
 
-#: user_management/views.py:172 user_management/views.py:175
+#: user_management/views.py:221 user_management/views.py:224
 msgid "Username already taken."
 msgstr "Benutzername schon vergeben."
 
-#: user_management/views.py:181
-msgid "Invalid display name. Display name must contain only letters, numbers, and underscores, and cannot be empty or contain only whitespace."
-msgstr "Ungültiger Anzeigename. Der Anzeigename darf nur Buchstaben, Zahlen und Unterstriche enthalten und darf nicht leer sein oder nur Leerzeichen enthalten."
+#: user_management/views.py:231
+msgid ""
+"Invalid display name. Display name must contain only letters, numbers, and "
+"underscores, and cannot be empty or contain only whitespace."
+msgstr ""
+"Ungültiger Anzeigename. Der Anzeigename darf nur Buchstaben, Zahlen und "
+"Unterstriche enthalten und darf nicht leer sein oder nur Leerzeichen "
+"enthalten."
 
-#: user_management/views.py:186 user_management/views.py:189
+#: user_management/views.py:237 user_management/views.py:240
 msgid "Display name already taken."
 msgstr "Anzeigename schon vergeben."
 
-#: user_management/views.py:206
+#: user_management/views.py:257
 msgid "Invalid current password."
 msgstr "Ungültiges aktuelles Passwort."
 
-#: user_management/views.py:211
+#: user_management/views.py:262
 msgid "Password changed successfully."
 msgstr "Passwort wurde erfolgreich geändert."

--- a/backend/locale/de/LC_MESSAGES/djangojs.po
+++ b/backend/locale/de/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-08 17:16+0000\n"
+"POT-Creation-Date: 2025-02-12 12:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,41 +23,83 @@ msgid "Refresh"
 msgstr "Aktualisieren"
 
 #: dashboard/static/dashboard/js/dashboard.js:28
-#: dashboard/static/dashboard/js/profile.js:40
+#: dashboard/static/dashboard/js/profile.js:64
+#: dashboard/static/dashboard/js/profile.js:107
 msgid "'s profile picture"
 msgstr "s Profilbild"
 
-#: dashboard/static/dashboard/js/profile.js:12
+#: dashboard/static/dashboard/js/profile.js:11
+msgid "Blocked Users"
+msgstr "Geblockte Nutzer"
+
+#: dashboard/static/dashboard/js/profile.js:16
 msgid "Quiz Stats"
 msgstr "Quiz-Statistiken"
 
-#: dashboard/static/dashboard/js/profile.js:42
+#: dashboard/static/dashboard/js/profile.js:57
+msgid "Error loading profile for"
+msgstr "Fehler beim Laden des Profils von"
+
+#: dashboard/static/dashboard/js/profile.js:66
+#: dashboard/static/dashboard/js/profile.js:109
 msgid "'s Profile"
 msgstr "s Profil"
 
-#: dashboard/static/dashboard/js/profile.js:46
+#: dashboard/static/dashboard/js/profile.js:76
+#: dashboard/static/dashboard/js/profile.js:125
+#: dashboard/static/dashboard/js/profile.js:155
+#: dashboard/static/dashboard/js/profile.js:236
+#: dashboard/static/dashboard/js/profile.js:245
+#: dashboard/static/dashboard/js/profile.js:280
+msgid "Unblock"
+msgstr "Entblocken"
+
+#: dashboard/static/dashboard/js/profile.js:78
+#: dashboard/static/dashboard/js/profile.js:81
+#: dashboard/static/dashboard/js/profile.js:127
+#: dashboard/static/dashboard/js/profile.js:130
+#: dashboard/static/dashboard/js/profile.js:181
+#: dashboard/static/dashboard/js/profile.js:259
+msgid "Block"
+msgstr "Blocken"
+
+#: dashboard/static/dashboard/js/profile.js:94
 msgid "Games Played:"
 msgstr "Gespielte Partien:"
 
-#: dashboard/static/dashboard/js/profile.js:47
+#: dashboard/static/dashboard/js/profile.js:95
 msgid "Games Won:"
 msgstr "Gewonnene Partien:"
 
-#: dashboard/static/dashboard/js/profile.js:48
+#: dashboard/static/dashboard/js/profile.js:96
 msgid "Total Score:"
 msgstr "Gesamtpunktzahl:"
 
-#: dashboard/static/dashboard/js/profile.js:49
+#: dashboard/static/dashboard/js/profile.js:97
 msgid "High Score:"
 msgstr "Höchste Punktzahl:"
 
-#: dashboard/static/dashboard/js/profile.js:50
+#: dashboard/static/dashboard/js/profile.js:98
 msgid "Questions Asked:"
 msgstr "Gestellte Fragen:"
 
-#: dashboard/static/dashboard/js/profile.js:51
+#: dashboard/static/dashboard/js/profile.js:99
 msgid "Correct Answers:"
 msgstr "Richtige Antworten:"
+
+#: dashboard/static/dashboard/js/profile.js:115
+msgid "This user has blocked you. You cannot view their profile."
+msgstr "Dieser Nutzer hat dich geblockt. Du kannst ihr Profil nicht ansehen."
+
+#: dashboard/static/dashboard/js/profile.js:199
+#: quiz/static/quiz/js/room_display.js:27
+#: quiz/static/quiz/js/room_display.js:32
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: dashboard/static/dashboard/js/profile.js:227
+msgid "No blocked users"
+msgstr "Keine geblockten Nutzer"
 
 #: quiz/static/quiz/js/quiz_logic.js:134 quiz/static/quiz/js/quiz_logic.js:149
 #: quiz/static/quiz/js/quiz_logic.js:153
@@ -75,7 +117,8 @@ msgstr "Du bist dem Raum beigetreten!"
 
 #: quiz/static/quiz/js/room_display.js:15
 msgid "Here you can start participating in the quiz."
-msgstr "Hier kannst du am Quiz teilnehmen. (Die Fragen im Quiz sind auf Englisch!)"
+msgstr ""
+"Hier kannst du am Quiz teilnehmen. (Die Fragen im Quiz sind auf Englisch!)"
 
 #: quiz/static/quiz/js/room_display.js:16
 msgid "Start Game"
@@ -84,10 +127,6 @@ msgstr "Spiel starten"
 #: quiz/static/quiz/js/room_display.js:20
 msgid "Leave Room"
 msgstr "Raum verlassen"
-
-#: quiz/static/quiz/js/room_display.js:32
-msgid "Settings"
-msgstr "Einstellungen"
 
 #: quiz/static/quiz/js/room_display.js:201
 msgid "Participants:"
@@ -144,7 +183,8 @@ msgstr "Fehler beim laden der Räume. Versuche es später nocheinmal"
 
 #: quiz/static/quiz/js/room_list.js:148
 msgid "No rooms available. Create a new room to get started."
-msgstr "Keine Räume verfügbar. Erstelle einen neuen Raum um ein Quiz zu starten."
+msgstr ""
+"Keine Räume verfügbar. Erstelle einen neuen Raum um ein Quiz zu starten."
 
 #: quiz/static/quiz/js/room_list.js:154
 msgid "Last activity:"
@@ -178,6 +218,14 @@ msgstr "Anmelden"
 #: user_management/static/users/js/logout.js:17
 msgid "Register"
 msgstr "Registrieren"
+
+#: static/js/router.js:35
+msgid "Page not found!"
+msgstr "Seite konnte nicht gefunden werden!"
+
+#: static/js/router.js:36
+msgid "Please ensure the current URL is correct."
+msgstr "Bitte stelle sicher, dass die aktuelle URL korrekt ist."
 
 #: user_management/static/users/js/account.js:13
 msgid "Your Profile Picture"
@@ -236,23 +284,23 @@ msgstr "Speichern"
 msgid "'s profile"
 msgstr "s Profil"
 
-#: user_management/static/users/js/account.js:109
+#: user_management/static/users/js/account.js:110
 msgid "Password is required."
 msgstr "Passwort ist erforderlich."
 
-#: user_management/static/users/js/account.js:136
+#: user_management/static/users/js/account.js:137
 msgid "No changes detected."
 msgstr "Keine Änderungen gefunden."
 
-#: user_management/static/users/js/account.js:140
+#: user_management/static/users/js/account.js:141
 msgid "Password is required to update profile data."
 msgstr "Das Passwort ist notwendig um die Profildaten zu ändern."
 
-#: user_management/static/users/js/account.js:211
+#: user_management/static/users/js/account.js:212
 msgid "All fields are required."
 msgstr "Alle Felder müssen ausgefüllt sein."
 
-#: user_management/static/users/js/account.js:215
+#: user_management/static/users/js/account.js:216
 msgid "New password and repeat password do not match."
 msgstr "Neues Passwort und Passwortwiederholung stimmen nicht überein."
 

--- a/backend/locale/sv/LC_MESSAGES/django.po
+++ b/backend/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-08 17:45+0000\n"
+"POT-Creation-Date: 2025-02-12 12:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,68 +54,91 @@ msgstr "Svenska"
 msgid "German"
 msgstr "Tyska"
 
-#: user_management/views.py:41
-msgid "Passwords do not match."
-msgstr "Lösenorden stämmer inte överens."
+#: user_management/views.py:40
+#, fuzzy
+#| msgid "Password changed successfully."
+msgid "User blocked successfully."
+msgstr "Lösenordet har ändrats framgångsrikt."
 
-#: user_management/views.py:50
-msgid "Account created successfully."
-msgstr "Konto har skapats framgångsrikt."
-
-#: user_management/views.py:52 user_management/views.py:74
-#: user_management/views.py:89 user_management/views.py:110
-#: user_management/views.py:143 user_management/views.py:212
+#: user_management/views.py:42 user_management/views.py:56
+#: user_management/views.py:99 user_management/views.py:121
+#: user_management/views.py:136 user_management/views.py:157
+#: user_management/views.py:190 user_management/views.py:263
 msgid "Invalid request method."
 msgstr "Ogiltig metod för begäran."
 
-#: user_management/views.py:69
+#: user_management/views.py:54
+#, fuzzy
+#| msgid "Password changed successfully."
+msgid "User unblocked successfully."
+msgstr "Lösenordet har ändrats framgångsrikt."
+
+#: user_management/views.py:88
+msgid "Passwords do not match."
+msgstr "Lösenorden stämmer inte överens."
+
+#: user_management/views.py:97
+msgid "Account created successfully."
+msgstr "Konto har skapats framgångsrikt."
+
+#: user_management/views.py:116
 msgid "Login successful."
 msgstr "Inloggningen lyckades."
 
-#: user_management/views.py:72
+#: user_management/views.py:119
 msgid "Invalid username or password!"
 msgstr "Ogiltigt användarnamn eller lösenord!"
 
-#: user_management/views.py:86
+#: user_management/views.py:133
 msgid "Logout successful."
 msgstr "Utloggningen lyckades."
 
-#: user_management/views.py:132
+#: user_management/views.py:179
 msgid "Invalid password."
 msgstr "Ogiltigt lösenord."
 
-#: user_management/views.py:142
+#: user_management/views.py:189
 msgid "Profile updated successfully."
 msgstr "Profilen uppdaterades framgångsrikt."
 
-#: user_management/views.py:151
+#: user_management/views.py:198
 msgid "Invalid email address."
 msgstr "Ogiltig e-postadress."
 
-#: user_management/views.py:155 user_management/views.py:160
+#: user_management/views.py:202 user_management/views.py:207
 msgid "An Account with this email already exists."
 msgstr "Ett konto med den här e-postadressen finns redan."
 
-#: user_management/views.py:167
-msgid "Invalid username. Username must contain only letters, numbers, and underscores, and cannot be empty or contain only whitespace."
-msgstr "Ogiltigt användarnamn. Användarnamnet får endast innehålla bokstäver, siffror och understreck och får inte vara tomt eller innehålla enbart blanksteg."
+#: user_management/views.py:215
+msgid ""
+"Invalid username. Username must contain only letters, numbers, and "
+"underscores, and cannot be empty or contain only whitespace."
+msgstr ""
+"Ogiltigt användarnamn. Användarnamnet får endast innehålla bokstäver, "
+"siffror och understreck och får inte vara tomt eller innehålla enbart "
+"blanksteg."
 
-#: user_management/views.py:172 user_management/views.py:175
+#: user_management/views.py:221 user_management/views.py:224
 msgid "Username already taken."
 msgstr "Användarnamn redan taget."
 
-#: user_management/views.py:181
-msgid "Invalid display name. Display name must contain only letters, numbers, and underscores, and cannot be empty or contain only whitespace."
-msgstr "Ogiltigt visningsnamn. Visningsnamnet får endast innehålla bokstäver, siffror och understreck och får inte vara tomt eller innehålla enbart blanksteg."
+#: user_management/views.py:231
+msgid ""
+"Invalid display name. Display name must contain only letters, numbers, and "
+"underscores, and cannot be empty or contain only whitespace."
+msgstr ""
+"Ogiltigt visningsnamn. Visningsnamnet får endast innehålla bokstäver, "
+"siffror och understreck och får inte vara tomt eller innehålla enbart "
+"blanksteg."
 
-#: user_management/views.py:186 user_management/views.py:189
+#: user_management/views.py:237 user_management/views.py:240
 msgid "Display name already taken."
 msgstr "Visningsnamnet är redan upptaget."
 
-#: user_management/views.py:206
+#: user_management/views.py:257
 msgid "Invalid current password."
 msgstr "Ogiltigt aktuellt lösenord."
 
-#: user_management/views.py:211
+#: user_management/views.py:262
 msgid "Password changed successfully."
 msgstr "Lösenordet har ändrats framgångsrikt."

--- a/backend/locale/sv/LC_MESSAGES/django.po
+++ b/backend/locale/sv/LC_MESSAGES/django.po
@@ -58,7 +58,7 @@ msgstr "Tyska"
 #, fuzzy
 #| msgid "Password changed successfully."
 msgid "User blocked successfully."
-msgstr "Lösenordet har ändrats framgångsrikt."
+msgstr "Användaren blockerades framgångsrikt."
 
 #: user_management/views.py:42 user_management/views.py:56
 #: user_management/views.py:99 user_management/views.py:121
@@ -71,7 +71,7 @@ msgstr "Ogiltig metod för begäran."
 #, fuzzy
 #| msgid "Password changed successfully."
 msgid "User unblocked successfully."
-msgstr "Lösenordet har ändrats framgångsrikt."
+msgstr "Användaren avblockerades framgångsrikt."
 
 #: user_management/views.py:88
 msgid "Passwords do not match."

--- a/backend/locale/sv/LC_MESSAGES/djangojs.po
+++ b/backend/locale/sv/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-08 17:16+0000\n"
+"POT-Creation-Date: 2025-02-12 12:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,41 +23,83 @@ msgid "Refresh"
 msgstr "Uppdatera"
 
 #: dashboard/static/dashboard/js/dashboard.js:28
-#: dashboard/static/dashboard/js/profile.js:40
+#: dashboard/static/dashboard/js/profile.js:64
+#: dashboard/static/dashboard/js/profile.js:107
 msgid "'s profile picture"
 msgstr "'s profilbild"
 
-#: dashboard/static/dashboard/js/profile.js:12
+#: dashboard/static/dashboard/js/profile.js:11
+msgid "Blocked Users"
+msgstr "Blockerade användare"
+
+#: dashboard/static/dashboard/js/profile.js:16
 msgid "Quiz Stats"
 msgstr "Statistik för frågesport"
 
-#: dashboard/static/dashboard/js/profile.js:42
+#: dashboard/static/dashboard/js/profile.js:57
+msgid "Error loading profile for"
+msgstr "Fel vid inläsning av profil för"
+
+#: dashboard/static/dashboard/js/profile.js:66
+#: dashboard/static/dashboard/js/profile.js:109
 msgid "'s Profile"
 msgstr "'s Profil"
 
-#: dashboard/static/dashboard/js/profile.js:46
+#: dashboard/static/dashboard/js/profile.js:76
+#: dashboard/static/dashboard/js/profile.js:125
+#: dashboard/static/dashboard/js/profile.js:155
+#: dashboard/static/dashboard/js/profile.js:236
+#: dashboard/static/dashboard/js/profile.js:245
+#: dashboard/static/dashboard/js/profile.js:280
+msgid "Unblock"
+msgstr "Avblockera"
+
+#: dashboard/static/dashboard/js/profile.js:78
+#: dashboard/static/dashboard/js/profile.js:81
+#: dashboard/static/dashboard/js/profile.js:127
+#: dashboard/static/dashboard/js/profile.js:130
+#: dashboard/static/dashboard/js/profile.js:181
+#: dashboard/static/dashboard/js/profile.js:259
+msgid "Block"
+msgstr "Block"
+
+#: dashboard/static/dashboard/js/profile.js:94
 msgid "Games Played:"
 msgstr "Spelade matcher:"
 
-#: dashboard/static/dashboard/js/profile.js:47
+#: dashboard/static/dashboard/js/profile.js:95
 msgid "Games Won:"
 msgstr "Vunna matcher:"
 
-#: dashboard/static/dashboard/js/profile.js:48
+#: dashboard/static/dashboard/js/profile.js:96
 msgid "Total Score:"
 msgstr "Total poäng:"
 
-#: dashboard/static/dashboard/js/profile.js:49
+#: dashboard/static/dashboard/js/profile.js:97
 msgid "High Score:"
 msgstr "Högsta poäng:"
 
-#: dashboard/static/dashboard/js/profile.js:50
+#: dashboard/static/dashboard/js/profile.js:98
 msgid "Questions Asked:"
 msgstr "Frågor som ställts:"
 
-#: dashboard/static/dashboard/js/profile.js:51
+#: dashboard/static/dashboard/js/profile.js:99
 msgid "Correct Answers:"
 msgstr "Korrekta svar:"
+
+#: dashboard/static/dashboard/js/profile.js:115
+msgid "This user has blocked you. You cannot view their profile."
+msgstr "Den här användaren har blockerat dig. Du kan inte se deras profil."
+
+#: dashboard/static/dashboard/js/profile.js:199
+#: quiz/static/quiz/js/room_display.js:27
+#: quiz/static/quiz/js/room_display.js:32
+msgid "Settings"
+msgstr "Inställningar"
+
+#: dashboard/static/dashboard/js/profile.js:227
+msgid "No blocked users"
+msgstr "Inga blockerade användare"
 
 #: quiz/static/quiz/js/quiz_logic.js:134 quiz/static/quiz/js/quiz_logic.js:149
 #: quiz/static/quiz/js/quiz_logic.js:153
@@ -75,7 +117,8 @@ msgstr "Du har anslutit dig till rummet!"
 
 #: quiz/static/quiz/js/room_display.js:15
 msgid "Here you can start participating in the quiz."
-msgstr "Här kan du börja delta i frågesporten. (Varning: Frågesporten är på engelska)"
+msgstr ""
+"Här kan du börja delta i frågesporten. (Varning: Frågesporten är på engelska)"
 
 #: quiz/static/quiz/js/room_display.js:16
 msgid "Start Game"
@@ -84,10 +127,6 @@ msgstr "Starta spelet"
 #: quiz/static/quiz/js/room_display.js:20
 msgid "Leave Room"
 msgstr "Lämna rummet"
-
-#: quiz/static/quiz/js/room_display.js:32
-msgid "Settings"
-msgstr "Inställningar"
 
 #: quiz/static/quiz/js/room_display.js:201
 msgid "Participants:"
@@ -179,6 +218,14 @@ msgstr "Logga in"
 msgid "Register"
 msgstr "Registrera"
 
+#: static/js/router.js:35
+msgid "Page not found!"
+msgstr "Sidan hittades inte!"
+
+#: static/js/router.js:36
+msgid "Please ensure the current URL is correct."
+msgstr "Se till att den aktuella URL:en är korrekt."
+
 #: user_management/static/users/js/account.js:13
 msgid "Your Profile Picture"
 msgstr "Din profilbild"
@@ -236,23 +283,23 @@ msgstr "Spara"
 msgid "'s profile"
 msgstr "'s Profil"
 
-#: user_management/static/users/js/account.js:109
+#: user_management/static/users/js/account.js:110
 msgid "Password is required."
 msgstr "Lösenord krävs"
 
-#: user_management/static/users/js/account.js:136
+#: user_management/static/users/js/account.js:137
 msgid "No changes detected."
 msgstr "Inga förändringar upptäckta."
 
-#: user_management/static/users/js/account.js:140
+#: user_management/static/users/js/account.js:141
 msgid "Password is required to update profile data."
 msgstr "Lösenord krävs för att uppdatera profildata."
 
-#: user_management/static/users/js/account.js:211
+#: user_management/static/users/js/account.js:212
 msgid "All fields are required."
 msgstr "Alla fält måste fyllas i."
 
-#: user_management/static/users/js/account.js:215
+#: user_management/static/users/js/account.js:216
 msgid "New password and repeat password do not match."
 msgstr "Det nya lösenordet och det upprepade lösenordet stämmer inte överens."
 

--- a/backend/quiz/static/quiz/js/room_display.js
+++ b/backend/quiz/static/quiz/js/room_display.js
@@ -24,7 +24,7 @@ export function displayRoom(roomName) {
 		
 		<button id="settings-button" class="btn btn-primary" style="display: none;" title="Settings">
 			<i class="bi bi-gear-fill"></i>
-			<span class="sr-only">Settings</span>
+			<span class="sr-only">${gettext("Settings")}</span>
 		</button>
 
 		<div id="settings-menu" class="card" style="display: none;">

--- a/backend/user_management/views.py
+++ b/backend/user_management/views.py
@@ -64,7 +64,7 @@ def blocked_users(request):
 	"""
 	blocked_by_request_user = BlockedUsers.objects.filter(blocker=request.user)
 	if blocked_by_request_user.count() == 0:
-		return JsonResponse({'success': False, 'blocked_users': []})
+		return JsonResponse({'success': True, 'blocked_users': []})
 	return JsonResponse(
 		{
 			'success': True,


### PR DESCRIPTION
Added the block functionalities to the dashboard.

You can now block and unblock users from the dashboard.
You can only view the name and profile picture of a user that has blocked you. (and block them)

Changed the users own dashboard appeareance:
If the user is looking at one owns dashboard, instead of a block/unblock button a settings button appears, routing to /account/

Also added a "Blocked user" button. When clicked it shows all user blocked by the requester. They can be unblocked or blocked again in the list. Pressing the button closes and resets the list (unblocked users disappear on the next open)


Whats next for the dashboard?
- Add the tournament and pong statistics once able to
- Add friend add, friend remove and a friends list once the api exists